### PR TITLE
Implement Composite instructions and chase bugs related to linear algebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,12 +353,12 @@ void main () {
 |--|--|
 | OpVectorExtractDynamic | :white_check_mark: |
 | OpVectorInsertDynamic | :white_check_mark: |
-| OpVectorShuffle | :red_circle: |
-| OpCompositeConstruct |:red_circle:  |
-| OpCompositeExtract | :red_circle: |
-| OpCompositeInsert | :red_circle: |
-| OpCopyObject | :red_circle: |
-| OpTranspose | :red_circle: |
+| OpVectorShuffle | :white_check_mark: |
+| OpCompositeConstruct | :red_circle:  |
+| OpCompositeExtract | :white_check_mark: |
+| OpCompositeInsert | :white_check_mark: |
+| OpCopyObject | :white_check_mark: |
+| OpTranspose | :white_check_mark: |
 | OpCopyLogical | :red_circle: |
 
 </details>

--- a/run_local.py
+++ b/run_local.py
@@ -16,8 +16,8 @@ class BinariesConfig:
 
 @dataclass
 class LimitsConfig:
-    n_types: int = 40
-    n_constants: int = 50
+    n_types: int = 50
+    n_constants: int = 100
     n_functions: int = 1
     max_depth: int = 3
 

--- a/src/fuzzing_server.py
+++ b/src/fuzzing_server.py
@@ -366,6 +366,7 @@ class ShaderGenerator:
         capabilities = [
             OpCapability(capability=Capability.Shader),
             OpCapability(capability=Capability.Matrix),
+            # OpCapability(capability=Capability.Vector16),
         ]
         memory_model = OpMemoryModel(
             addressing_model=AddressingModel.Logical, memory_model=MemoryModel.GLSL450

--- a/src/operators/arithmetic/linear_algebra.py
+++ b/src/operators/arithmetic/linear_algebra.py
@@ -135,27 +135,26 @@ class OpMatrixTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
         operand2 = context.get_random_operand(
             lambda x: (IsMatrixType(x) and HasFloatBaseType(x))
             and (
-                #     len(x.type) == len(operand1.type.type)
-                # <=> # columns of operand2 == # rows of operand1
-                # <=> the trivial case
-                HaveSameTypeLength(x, operand1.type)
                 #     len(x.type.type) == len(operand1.type)
                 # <=> # rows of operand2 == # columns of operand1
+                # <=> the trivial case
+                HaveSameTypeLength(x.type, operand1)
+                #     len(x.type) == len(operand1.type.type)
+                # <=> # columns of operand2 == # rows of operand1
                 # <=> the symmetric case
-                or HaveSameTypeLength(x.type, operand1)
+                or HaveSameTypeLength(x, operand1.type)
             )
         )
         if not operand2:
             return []
 
         # Handle the symmetric case
-        #     len(operand1.type.type) != len(operand2.type)
-        # <=> # rows of operand1 != # columns of operand2
+        #     len(operand1.type) != len(operand2.type.type)
+        # <=> # columns of operand1 != # rows of operand2
         # <=> the symmetric case
-        if len(operand1.type.type) != len(operand2.type):
+        if len(operand1.type) != len(operand2.type.type):
             operand1, operand2 = operand2, operand1
 
-        assert len(operand1.type.type) == len(operand2.type)
         # The resulting matrix has the same number of rows as operand1
         # and same number of columns as operand2
         self.type = OpTypeMatrix()

--- a/src/operators/arithmetic/linear_algebra.py
+++ b/src/operators/arithmetic/linear_algebra.py
@@ -13,7 +13,6 @@ from src.predicates import (
     HasBaseType,
     HasFloatBaseType,
     HasLength,
-    HasValidBaseType,
     HaveSameTypeLength,
     IsMatrixType,
     IsScalarFloat,

--- a/src/operators/arithmetic/linear_algebra.py
+++ b/src/operators/arithmetic/linear_algebra.py
@@ -9,6 +9,10 @@ from src.operators.arithmetic import BinaryArithmeticOperator
 if TYPE_CHECKING:
     from src.context import Context
 from src.predicates import (
+    And,
+    HasBaseType,
+    HasFloatBaseType,
+    HasLength,
     HasValidBaseType,
     HaveSameTypeLength,
     IsMatrixType,
@@ -33,9 +37,7 @@ class OpVectorTimesScalar(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        operand1 = context.get_random_operand(
-            lambda x: IsVectorType(x) and HasValidBaseType(x, OpTypeFloat)
-        )
+        operand1 = context.get_random_operand(And(IsVectorType, HasFloatBaseType))
         if not operand1:
             return []
         operand2 = context.get_random_operand(IsScalarFloat)
@@ -53,9 +55,7 @@ class OpMatrixTimesScalar(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        operand1 = context.get_random_operand(
-            lambda x: IsMatrixType(x) and HasValidBaseType(x, OpTypeFloat)
-        )
+        operand1 = context.get_random_operand(And(IsMatrixType, HasFloatBaseType))
         if not operand1:
             return []
         operand2 = context.get_random_operand(IsScalarFloat)
@@ -74,22 +74,18 @@ class OpVectorTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
 
     def fuzz(self, context: "Context") -> list[OpCode]:
         # We pick the matrix first here because we tend to have more vectors than matrices
-        operand2 = context.get_random_operand(
-            lambda x: IsMatrixType(x) and HasValidBaseType(x, OpTypeFloat)
-        )
+        operand2 = context.get_random_operand(And(IsMatrixType, HasFloatBaseType))
         if not operand2:
             return []
         # The vector must have as many element as the matrix has rows
         operand1 = context.get_random_operand(
-            lambda x: IsVectorType(x)
-            and HasValidBaseType(x, OpTypeFloat)
-            and HaveSameTypeLength(x, operand2.type)
+            And(IsVectorType, HasFloatBaseType, HasLength(len(operand2.type.type)))
         )
         if not operand1:
             return []
         self.type = OpTypeVector()
         self.type.type = operand1.get_base_type()
-        self.type.size = len(operand2.type.type)
+        self.type.size = len(operand2.type)
         context.add_to_tvc(self.type)
         self.operand1 = operand1
         self.operand2 = operand2
@@ -102,23 +98,18 @@ class OpMatrixTimesVector(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        # We pick the matrix first here because we tend to have more vectors than matrices
+        operand1 = context.get_random_operand(And(IsMatrixType, HasFloatBaseType))
+        if not operand1:
+            return []
+        # The vector must have as many elements as the matrix has columns
         operand2 = context.get_random_operand(
-            lambda x: IsMatrixType(x) and HasValidBaseType(x, OpTypeFloat)
+            And(IsVectorType, HasFloatBaseType, HasLength(len(operand1.type)))
         )
         if not operand2:
             return []
-        # The vector must have as many elements as the matrix has columns
-        operand1 = context.get_random_operand(
-            lambda x: IsVectorType(x)
-            and HasValidBaseType(x, OpTypeFloat)
-            and HaveSameTypeLength(x, operand2)
-        )
-        if not operand1:
-            return []
         self.type = OpTypeVector()
         self.type.type = operand1.get_base_type()
-        self.type.size = len(operand2.type.type)
+        self.type.size = len(operand1.type.type)
         context.add_to_tvc(self.type)
         self.operand1 = operand1
         self.operand2 = operand2
@@ -131,9 +122,7 @@ class OpMatrixTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        operand1 = context.get_random_operand(
-            lambda x: IsMatrixType(x) and HasValidBaseType(x, OpTypeFloat)
-        )
+        operand1 = context.get_random_operand(And(IsMatrixType, HasFloatBaseType))
         if not operand1:
             return []
         # operand2 must have the same number of columns that operand1 has
@@ -141,12 +130,18 @@ class OpMatrixTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
         # a matrix that could be multiplied by operand2 in the symmetric case
         #
         # e.g. we picked a mat2x4 for operand1 and the only other matrix
-        # in scope is a mat5x2. We can't multiply them together, but we can
-        # swap them around to solve this.
+        # in scope is a mat3x2. We can't multiply them together, but we can
+        # swap them around to resolve this.
         operand2 = context.get_random_operand(
-            lambda x: (IsMatrixType(x) and HasValidBaseType(x, OpTypeFloat))
+            lambda x: (IsMatrixType(x) and HasFloatBaseType(x))
             and (
+                #     len(x.type) == len(operand1.type.type)
+                # <=> # columns of operand2 == # rows of operand1
+                # <=> the trivial case
                 HaveSameTypeLength(x, operand1.type)
+                #     len(x.type.type) == len(operand1.type)
+                # <=> # rows of operand2 == # columns of operand1
+                # <=> the symmetric case
                 or HaveSameTypeLength(x.type, operand1)
             )
         )
@@ -154,9 +149,13 @@ class OpMatrixTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
             return []
 
         # Handle the symmetric case
+        #     len(operand1.type.type) != len(operand2.type)
+        # <=> # rows of operand1 != # columns of operand2
+        # <=> the symmetric case
         if len(operand1.type.type) != len(operand2.type):
             operand1, operand2 = operand2, operand1
 
+        assert len(operand1.type.type) == len(operand2.type)
         # The resulting matrix has the same number of rows as operand1
         # and same number of columns as operand2
         self.type = OpTypeMatrix()
@@ -164,6 +163,7 @@ class OpMatrixTimesMatrix(BinaryArithmeticOperator[None, None, None, None]):
         self.type.type = operand1.type.type
         # Columns
         self.type.size = len(operand2.type)
+        context.add_to_tvc(self.type)
         self.operand1 = operand1
         self.operand2 = operand2
         return [self]
@@ -175,11 +175,10 @@ class OpOuterProduct(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        predicate = lambda x: IsVectorType(x) and HasValidBaseType(x, OpTypeFloat)
-        operand1 = context.get_random_operand(predicate)
+        operand1 = context.get_random_operand(And(IsVectorType, HasFloatBaseType))
         if not operand1:
             return []
-        operand2 = context.get_random_operand(predicate)
+        operand2 = context.get_random_operand(And(IsVectorType, HasFloatBaseType))
         self.type = OpTypeMatrix()
         self.type.type = operand1.type
         self.type.size = len(operand2.type)
@@ -195,11 +194,16 @@ class OpDot(BinaryArithmeticOperator[None, None, None, None]):
     operand2: Operand = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        predicate = lambda x: IsVectorType(x) and HasValidBaseType(x, OpTypeFloat)
-        operand1 = context.get_random_operand(predicate)
+        operand1 = context.get_random_operand(And(IsVectorType, HasFloatBaseType))
         if not operand1:
             return []
-        operand2 = context.get_random_operand(predicate, operand1)
+        operand2 = context.get_random_operand(
+            And(
+                IsVectorType,
+                HasBaseType(operand1.get_base_type()),
+                HasLength(len(operand1.type)),
+            )
+        )
         self.type = operand1.get_base_type()
         self.operand1 = operand1
         self.operand2 = operand2

--- a/src/operators/bitwise.py
+++ b/src/operators/bitwise.py
@@ -1,5 +1,4 @@
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Generic,
     Optional,

--- a/src/operators/composite.py
+++ b/src/operators/composite.py
@@ -1,10 +1,18 @@
+import random
 from typing import TYPE_CHECKING
 from src import OpCode, Statement, Type
+from src.operators import Operand
 from src.predicates import (
+    HasValidBaseTypeAndSign,
     HasValidTypeAndSign,
+    IsArrayType,
+    IsCompositeType,
+    IsMatrixType,
     IsScalarInteger,
+    IsStructType,
     IsVectorType,
 )
+from src.types.concrete_types import OpTypeMatrix, OpTypeVector
 
 if TYPE_CHECKING:
     from src.context import Context
@@ -53,4 +61,137 @@ class OpVectorInsertDynamic(CompositeOperator):
         self.vector = vector
         self.component = component
         self.index = context.get_random_operand(IsScalarInteger)
+        return [self]
+
+
+# class OpVectorShuffle(CompositeOperator):
+#     type: Type = None
+#     vector1: Statement = None
+#     vector2: Statement = None
+#     indices: Statement = None
+
+#     def fuzz(self, context: "Context") -> list[OpCode]:
+#         vector1 = context.get_random_operand(IsVectorType)
+#         if vector1 is None:
+#             return []
+#         signedness = None
+#         if hasattr(vector1.get_base_type(), "signed"):
+#             signedness = vector1.get_base_type().signed
+#         vector2 = context.get_random_operand(
+#             lambda x: IsVectorType(x)
+#             and HasValidBaseTypeAndSign(x, vector1.get_base_type(), signedness)
+#         )
+#         if vector2 is None:
+#             return []
+#         # indices = ???
+#         self.type = vector1.type
+#         self.vector1 = vector1
+#         self.vector2 = vector2
+#         self.indices = indices
+#         return [self]
+
+# class OpCompositeConstruct:
+#     ...
+
+
+class OpCompositeExtract(CompositeOperator):
+    type: Type = None
+    composite: Operand = None
+    indexes: tuple[int] = None
+
+    def fuzz(self, context: "Context") -> list[OpCode]:
+        composite = context.get_random_operand(IsCompositeType)
+        if composite is None:
+            return []
+        if IsMatrixType(composite):
+            indexes = (
+                random.SystemRandom().randint(0, len(composite.type) - 1),
+                random.SystemRandom().randint(0, len(composite.type.type) - 1),
+            )
+            type = composite.get_base_type()
+        else:
+            indexes = (random.SystemRandom().randint(0, len(composite.type) - 1),)
+            type = (
+                composite.type.types[indexes[0]]
+                if IsStructType(composite)
+                else composite.get_base_type()
+            )
+        self.type = type
+        self.composite = composite
+        self.indexes = indexes
+        return [self]
+
+
+class OpCompositeInsert(CompositeOperator):
+    type: Type = None
+    object: Statement = None
+    composite: Statement = None
+    indexes: tuple[int] = None
+
+    def fuzz(self, context: "Context") -> list[OpCode]:
+        composite = context.get_random_operand(IsCompositeType)
+        if composite is None:
+            return []
+        if IsMatrixType(composite):
+            indexes = (
+                random.SystemRandom().randint(0, len(composite.type) - 1),
+                random.SystemRandom().randint(0, len(composite.type.type) - 1),
+            )
+            signedness = None
+            if hasattr(composite.get_base_type(), "signed"):
+                signedness = composite.get_base_type().signed
+            object = context.get_random_operand(
+                lambda x: HasValidTypeAndSign(
+                    x, composite.get_base_type().__class__, signedness
+                )
+            )
+        else:
+            indexes = (random.SystemRandom().randint(0, len(composite.type) - 1),)
+            target_type = (
+                composite.type.types[indexes[0]]
+                if IsStructType(composite)
+                else composite.get_base_type()
+            )
+            signedness = None
+            if hasattr(target_type, "signed"):
+                signedness = target_type.signed
+            object = context.get_random_operand(
+                lambda x: HasValidTypeAndSign(x, target_type.__class__, signedness)
+            )
+        self.type = composite.type
+        self.object = object
+        self.composite = composite
+        self.indexes = indexes
+        return [self]
+
+
+class OpCopyObject(CompositeOperator):
+    type: Type = None
+    object: Statement = None
+
+    def fuzz(self, context: "Context") -> list[OpCode]:
+        object = context.get_random_operand(lambda _: True)
+        if object is None:
+            return []
+        self.type = object.type
+        self.object = object
+        return [self]
+
+
+class OpTranspose(CompositeOperator):
+    type: Type = None
+    object: Statement = None
+
+    def fuzz(self, context: "Context") -> list[OpCode]:
+        object = context.get_random_operand(IsMatrixType)
+        if object is None:
+            return []
+        self.type = OpTypeMatrix()
+        self.type.type = OpTypeVector()
+        self.type.type.type = object.get_base_type()
+        self.type.type.size = len(object.type)
+        self.type.size = len(object.type.type)
+        context.add_to_tvc(self.type.type)
+        context.add_to_tvc(self.type)
+        self.object = object
         return [self]

--- a/src/operators/composite.py
+++ b/src/operators/composite.py
@@ -1,18 +1,19 @@
+from math import ceil, log2
 import random
 from typing import TYPE_CHECKING
 from src import OpCode, Statement, Type
 from src.operators import Operand
 from src.predicates import (
-    HasValidBaseTypeAndSign,
-    HasValidTypeAndSign,
-    IsArrayType,
+    And,
+    HasBaseType,
+    HasType,
     IsCompositeType,
     IsMatrixType,
     IsScalarInteger,
     IsStructType,
     IsVectorType,
 )
-from src.types.concrete_types import OpTypeMatrix, OpTypeVector
+from src.types.concrete_types import OpTypeInt, OpTypeMatrix, OpTypeStruct, OpTypeVector
 
 if TYPE_CHECKING:
     from src.context import Context
@@ -48,13 +49,7 @@ class OpVectorInsertDynamic(CompositeOperator):
         vector = context.get_random_operand(IsVectorType)
         if vector is None:
             return []
-        base_type = vector.get_base_type()
-        signedness = None
-        if hasattr(base_type, "signed"):
-            signedness = base_type.signed
-        component = context.get_random_operand(
-            lambda x: HasValidTypeAndSign(x, base_type.__class__, signedness)
-        )
+        component = context.get_random_operand(HasType(vector.get_base_type()))
         if component is None:
             return []
         self.type = vector.type
@@ -64,31 +59,38 @@ class OpVectorInsertDynamic(CompositeOperator):
         return [self]
 
 
-# class OpVectorShuffle(CompositeOperator):
-#     type: Type = None
-#     vector1: Statement = None
-#     vector2: Statement = None
-#     indices: Statement = None
+class OpVectorShuffle(CompositeOperator):
+    type: Type = None
+    vector1: Statement = None
+    vector2: Statement = None
+    components: tuple[int] = None
 
-#     def fuzz(self, context: "Context") -> list[OpCode]:
-#         vector1 = context.get_random_operand(IsVectorType)
-#         if vector1 is None:
-#             return []
-#         signedness = None
-#         if hasattr(vector1.get_base_type(), "signed"):
-#             signedness = vector1.get_base_type().signed
-#         vector2 = context.get_random_operand(
-#             lambda x: IsVectorType(x)
-#             and HasValidBaseTypeAndSign(x, vector1.get_base_type(), signedness)
-#         )
-#         if vector2 is None:
-#             return []
-#         # indices = ???
-#         self.type = vector1.type
-#         self.vector1 = vector1
-#         self.vector2 = vector2
-#         self.indices = indices
-#         return [self]
+    def fuzz(self, context: "Context") -> list[OpCode]:
+        vector1 = context.get_random_operand(IsVectorType)
+        if vector1 is None:
+            return []
+        vector2 = context.get_random_operand(
+            And(IsVectorType, HasBaseType(vector1.get_base_type()))
+        )
+        if vector2 is None:
+            return []
+
+        self.type = OpTypeVector()
+        self.type.type = vector1.get_base_type()
+        self.type.size = min(
+            4, 2 ** (ceil(log2(len(vector1.type) + len(vector2.type))))
+        )
+        context.add_to_tvc(self.type)
+        self.vector1 = vector1
+        self.vector2 = vector2
+        self.components = tuple(
+            [
+                random.SystemRandom().randint(0, self.type.size - 1)
+                for _ in range(self.type.size)
+            ]
+        )
+        return [self]
+
 
 # class OpCompositeConstruct:
 #     ...
@@ -137,14 +139,7 @@ class OpCompositeInsert(CompositeOperator):
                 random.SystemRandom().randint(0, len(composite.type) - 1),
                 random.SystemRandom().randint(0, len(composite.type.type) - 1),
             )
-            signedness = None
-            if hasattr(composite.get_base_type(), "signed"):
-                signedness = composite.get_base_type().signed
-            object = context.get_random_operand(
-                lambda x: HasValidTypeAndSign(
-                    x, composite.get_base_type().__class__, signedness
-                )
-            )
+            object = context.get_random_operand(HasType(composite.get_base_type()))
         else:
             indexes = (random.SystemRandom().randint(0, len(composite.type) - 1),)
             target_type = (
@@ -152,12 +147,11 @@ class OpCompositeInsert(CompositeOperator):
                 if IsStructType(composite)
                 else composite.get_base_type()
             )
-            signedness = None
-            if hasattr(target_type, "signed"):
-                signedness = target_type.signed
-            object = context.get_random_operand(
-                lambda x: HasValidTypeAndSign(x, target_type.__class__, signedness)
-            )
+            object = context.get_random_operand(HasType(target_type))
+            # There's no way we can't find a valid object. In the most
+            # boring case we can always just reinsert something that was
+            # already in there.
+            assert object is not None
         self.type = composite.type
         self.object = object
         self.composite = composite

--- a/src/operators/composite.py
+++ b/src/operators/composite.py
@@ -13,7 +13,7 @@ from src.predicates import (
     IsStructType,
     IsVectorType,
 )
-from src.types.concrete_types import OpTypeInt, OpTypeMatrix, OpTypeStruct, OpTypeVector
+from src.types.concrete_types import OpTypeMatrix, OpTypeVector
 
 if TYPE_CHECKING:
     from src.context import Context

--- a/src/operators/composite.py
+++ b/src/operators/composite.py
@@ -148,10 +148,6 @@ class OpCompositeInsert(CompositeOperator):
                 else composite.get_base_type()
             )
             object = context.get_random_operand(HasType(target_type))
-            # There's no way we can't find a valid object. In the most
-            # boring case we can always just reinsert something that was
-            # already in there.
-            assert object is not None
         self.type = composite.type
         self.object = object
         self.composite = composite

--- a/src/operators/composite.py
+++ b/src/operators/composite.py
@@ -110,15 +110,14 @@ class OpCompositeExtract(CompositeOperator):
                 random.SystemRandom().randint(0, len(composite.type) - 1),
                 random.SystemRandom().randint(0, len(composite.type.type) - 1),
             )
-            type = composite.get_base_type()
+            self.type = composite.get_base_type()
         else:
             indexes = (random.SystemRandom().randint(0, len(composite.type) - 1),)
-            type = (
+            self.type = (
                 composite.type.types[indexes[0]]
                 if IsStructType(composite)
                 else composite.get_base_type()
             )
-        self.type = type
         self.composite = composite
         self.indexes = indexes
         return [self]
@@ -139,7 +138,7 @@ class OpCompositeInsert(CompositeOperator):
                 random.SystemRandom().randint(0, len(composite.type) - 1),
                 random.SystemRandom().randint(0, len(composite.type.type) - 1),
             )
-            object = context.get_random_operand(HasType(composite.get_base_type()))
+            target_object = context.get_random_operand(HasType(composite.get_base_type()))
         else:
             indexes = (random.SystemRandom().randint(0, len(composite.type) - 1),)
             target_type = (
@@ -147,24 +146,24 @@ class OpCompositeInsert(CompositeOperator):
                 if IsStructType(composite)
                 else composite.get_base_type()
             )
-            object = context.get_random_operand(HasType(target_type))
+            target_object = context.get_random_operand(HasType(target_type))
         self.type = composite.type
-        self.object = object
+        self.object = target_object
         self.composite = composite
         self.indexes = indexes
         return [self]
 
 
-class OpCopyObject(CompositeOperator):
+class OpCopytarget_object(CompositeOperator):
     type: Type = None
     object: Statement = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        object = context.get_random_operand(lambda _: True)
-        if object is None:
+        target_object = context.get_random_operand(lambda _: True)
+        if target_object is None:
             return []
-        self.type = object.type
-        self.object = object
+        self.type = target_object.type
+        self.object = target_object
         return [self]
 
 
@@ -173,15 +172,15 @@ class OpTranspose(CompositeOperator):
     object: Statement = None
 
     def fuzz(self, context: "Context") -> list[OpCode]:
-        object = context.get_random_operand(IsMatrixType)
-        if object is None:
+        target_object = context.get_random_operand(IsMatrixType)
+        if target_object is None:
             return []
         self.type = OpTypeMatrix()
         self.type.type = OpTypeVector()
-        self.type.type.type = object.get_base_type()
-        self.type.type.size = len(object.type)
-        self.type.size = len(object.type.type)
+        self.type.type.type = target_object.get_base_type()
+        self.type.type.size = len(target_object.type)
+        self.type.size = len(target_object.type.type)
         context.add_to_tvc(self.type.type)
         context.add_to_tvc(self.type)
-        self.object = object
+        self.object = target_object
         return [self]

--- a/src/operators/conversions.py
+++ b/src/operators/conversions.py
@@ -1,5 +1,4 @@
 from typing import (
-
     Callable,
     Generic,
     Optional,

--- a/src/operators/conversions.py
+++ b/src/operators/conversions.py
@@ -1,5 +1,5 @@
 from typing import (
-    TYPE_CHECKING,
+
     Callable,
     Generic,
     Optional,

--- a/src/operators/logic.py
+++ b/src/operators/logic.py
@@ -1,5 +1,4 @@
 from typing import (
-    TYPE_CHECKING,
     Callable,
     Generic,
     Optional,

--- a/src/predicates.py
+++ b/src/predicates.py
@@ -1,17 +1,22 @@
 from src.enums import StorageClass
 from src.types.abstract_types import ArithmeticType
 from src.types.concrete_types import (
+    OpTypeArray,
     OpTypeBool,
     OpTypeFloat,
     OpTypeInt,
     OpTypeMatrix,
+    OpTypeStruct,
     OpTypeVector,
 )
 
 IsVectorType = lambda x: isinstance(x.type, OpTypeVector)
+IsArrayType = lambda x: isinstance(x.type, OpTypeArray)
 IsMatrixType = lambda x: isinstance(x.type, OpTypeMatrix)
+IsStructType = lambda x: isinstance(x.type, OpTypeStruct)
 IsScalarInteger = lambda x: isinstance(x.type, OpTypeInt)
 IsScalarFloat = lambda x: isinstance(x.type, OpTypeFloat)
+IsCompositeType = lambda x: isinstance(x.type, (OpTypeMatrix, OpTypeVector, OpTypeStruct, OpTypeArray))
 HasValidBaseType = lambda x, target_type: isinstance(x.get_base_type(), target_type)
 HasValidSign = (
     lambda x, signed: x.get_base_type().signed == signed if signed is not None else True

--- a/src/predicates.py
+++ b/src/predicates.py
@@ -10,13 +10,21 @@ from src.types.concrete_types import (
     OpTypeVector,
 )
 
+And = lambda *ps: lambda x: all(p(x) for p in ps)
+Or = lambda *ps: lambda x: any(p(x) for p in ps)
+Not = lambda p: lambda x: not p(x)
+
+HasFloatBaseType = lambda x: isinstance(x.get_base_type(), OpTypeFloat)
 IsVectorType = lambda x: isinstance(x.type, OpTypeVector)
 IsArrayType = lambda x: isinstance(x.type, OpTypeArray)
 IsMatrixType = lambda x: isinstance(x.type, OpTypeMatrix)
 IsStructType = lambda x: isinstance(x.type, OpTypeStruct)
 IsScalarInteger = lambda x: isinstance(x.type, OpTypeInt)
 IsScalarFloat = lambda x: isinstance(x.type, OpTypeFloat)
-IsCompositeType = lambda x: isinstance(x.type, (OpTypeMatrix, OpTypeVector, OpTypeStruct, OpTypeArray))
+
+IsCompositeType = lambda x: isinstance(
+    x.type, (OpTypeMatrix, OpTypeVector, OpTypeStruct, OpTypeArray)
+)
 HasValidBaseType = lambda x, target_type: isinstance(x.get_base_type(), target_type)
 HasValidSign = (
     lambda x, signed: x.get_base_type().signed == signed if signed is not None else True
@@ -29,6 +37,13 @@ HasValidTypeAndSign = lambda x, target_type, signed: HasValidType(
     x, target_type
 ) and HasValidSign(x, signed)
 HaveSameTypeLength = lambda x, y: len(x.type) == len(y.type)
+HaveSameType = lambda x, y: x.type == y.type
+HaveSameBaseType = lambda x, y: x.get_base_type() == y.get_base_type()
+
+HasType = lambda t: lambda x: x.type == t
+HasBaseType = lambda t: lambda x: x.get_base_type() == t
+HasLength = lambda n: lambda x: len(x.type) == n
+
 IsNotOutputVariable = lambda x: not x.storage_class == StorageClass.Output
 IsNotInputVariable = lambda x: not x.storage_class == StorageClass.Input
 IsValidArithmeticOperand = lambda x: isinstance(x.type, ArithmeticType)

--- a/src/types/concrete_types.py
+++ b/src/types/concrete_types.py
@@ -65,7 +65,7 @@ class OpTypeVector(UniformContainerType, ArithmeticType):
 
     def fuzz(self, context: "Context") -> list[OpCode]:
         self.type = ScalarType().fuzz(context)[0]
-        self.size = random.SystemRandom().choice([2, 3, 4])  # 8, 16])
+        self.size = random.SystemRandom().choice([2, 3, 4])
         return [self.type, self]
 
     def __len__(self):

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -88,7 +88,7 @@ class TestArithmetic(unittest.TestCase):
         )[-1]
 
         # The resulting vector must have as many elements as the matrix has columns
-        self.assertEqual(len(vector_times_matrix.type), len(outer_product.type.type))
+        self.assertEqual(len(vector_times_matrix.type), len(outer_product.type))
 
     def test_matrix_times_vector_has_correct_shape(self):
         create_vector_const(self.context, OpTypeFloat, size=4)
@@ -126,6 +126,11 @@ class TestArithmetic(unittest.TestCase):
             self.context
         )[-1]
 
+        # The left matrix should have as many rows as the right matrix has columns
+        self.assertEqual(
+            len(matrix_times_matrix.operand1.type.type),
+            len(matrix_times_matrix.operand2.type),
+        )
         # The resulting matrix must have as many rows as the first operand
         self.assertEqual(
             len(matrix_times_matrix.type.type),

--- a/tests/test_arithmetic.py
+++ b/tests/test_arithmetic.py
@@ -126,10 +126,10 @@ class TestArithmetic(unittest.TestCase):
             self.context
         )[-1]
 
-        # The left matrix should have as many rows as the right matrix has columns
+        # The left matrix should have as many columns as the right matrix has rows
         self.assertEqual(
-            len(matrix_times_matrix.operand1.type.type),
-            len(matrix_times_matrix.operand2.type),
+            len(matrix_times_matrix.operand1.type),
+            len(matrix_times_matrix.operand2.type.type),
         )
         # The resulting matrix must have as many rows as the first operand
         self.assertEqual(
@@ -138,5 +138,5 @@ class TestArithmetic(unittest.TestCase):
         )
         # The resulting matrix must have as many columns as the second operand
         self.assertEqual(
-            len(matrix_times_matrix.type.type), len(matrix_times_matrix.operand2.type)
+            len(matrix_times_matrix.type), len(matrix_times_matrix.operand2.type)
         )

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,0 +1,104 @@
+import copy
+import unittest
+from src import FuzzDelegator, Type
+from src.constants import (
+    OpConstant,
+    OpConstantComposite,
+)
+from src.monitor import Monitor
+from src.enums import ExecutionModel
+from src.context import Context
+from run_local import SPIRVSmithConfig
+from src.operators.arithmetic.linear_algebra import (
+    OpMatrixTimesMatrix,
+    OpMatrixTimesVector,
+    OpOuterProduct,
+    OpVectorTimesMatrix,
+    OpVectorTimesScalar,
+)
+from src.operators.composite import OpCompositeExtract, OpCompositeInsert, OpTranspose, OpVectorExtractDynamic, OpVectorInsertDynamic
+from src.types.concrete_types import OpTypeFloat, OpTypeInt, OpTypeVector
+
+N = 1000
+monitor = Monitor()
+config = SPIRVSmithConfig()
+init_strategy = copy.deepcopy(config.strategy)
+init_limits = copy.deepcopy(config.limits)
+
+config.misc.broadcast_generated_shaders = False
+config.misc.start_web_server = False
+
+
+def create_vector_const(context: Context, inner_type: Type, size: int = 4):
+    const: OpConstant = context.create_on_demand_numerical_constant(
+        inner_type, value=42, width=32
+    )
+
+    vector_type = OpTypeVector()
+    vector_type.type = const.type
+    vector_type.size = size
+    context.add_to_tvc(vector_type)
+
+    vector_const = OpConstantComposite()
+    vector_const.type = vector_type
+    vector_const.constituents = tuple([const for _ in range(size)])
+    context.add_to_tvc(vector_const)
+    return vector_const
+
+
+class TestArithmetic(unittest.TestCase):
+    def setUp(self):
+        FuzzDelegator.reset_parametrizations()
+        config.limits = copy.deepcopy(init_limits)
+        config.strategy = copy.deepcopy(init_strategy)
+        self.context: Context = Context.create_global_context(
+            ExecutionModel.GLCompute, config, monitor
+        )
+
+    def test_vector_dynamic_extract_has_correct_type(self):
+        vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
+
+        vector_extract: OpVectorExtractDynamic = OpVectorExtractDynamic().fuzz(
+            self.context
+        )[-1]
+
+        self.assertEqual(vector_extract.type, vec_const.get_base_type())
+    
+    def test_vector_insert_preserves_type(self):
+        vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
+
+        vector_insert: OpVectorInsertDynamic = OpVectorInsertDynamic().fuzz(
+            self.context
+        )[-1]
+
+        self.assertEqual(vector_insert.type, vec_const.type)
+
+    def test_composite_extract_has_correct_type(self):
+        vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
+
+        vector_extract: OpCompositeExtract = OpCompositeExtract().fuzz(
+            self.context
+        )[-1]
+
+        self.assertEqual(vector_extract.type, vec_const.get_base_type())
+
+    def test_composite_insert_preserves_type(self):
+        vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
+
+        vector_insert: OpCompositeInsert = OpCompositeInsert().fuzz(
+            self.context
+        )[-1]
+
+        self.assertEqual(vector_insert.type, vec_const.type)
+        
+    def test_transpose_has_correct_shape(self):
+        create_vector_const(self.context, OpTypeFloat, size=4)
+        create_vector_const(self.context, OpTypeFloat, size=2)
+
+        outer_product: OpOuterProduct = OpOuterProduct().fuzz(self.context)[-1]
+        self.context.symbol_table[outer_product] = outer_product.id
+        
+        transpose: OpTranspose = OpTranspose().fuzz(self.context)[-1]
+        
+        self.assertEqual(len(transpose.type), len(outer_product.type.type))
+        self.assertEqual(len(transpose.type.type), len(outer_product.type))

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -1,5 +1,6 @@
 import copy
 import unittest
+from run_local import SPIRVSmithConfig
 from src import FuzzDelegator, Type
 from src.constants import (
     OpConstant,
@@ -8,16 +9,17 @@ from src.constants import (
 from src.monitor import Monitor
 from src.enums import ExecutionModel
 from src.context import Context
-from run_local import SPIRVSmithConfig
 from src.operators.arithmetic.linear_algebra import (
-    OpMatrixTimesMatrix,
-    OpMatrixTimesVector,
     OpOuterProduct,
-    OpVectorTimesMatrix,
-    OpVectorTimesScalar,
 )
-from src.operators.composite import OpCompositeExtract, OpCompositeInsert, OpTranspose, OpVectorExtractDynamic, OpVectorInsertDynamic
-from src.types.concrete_types import OpTypeFloat, OpTypeInt, OpTypeVector
+from src.operators.composite import (
+    OpCompositeExtract,
+    OpCompositeInsert,
+    OpTranspose,
+    OpVectorExtractDynamic,
+    OpVectorInsertDynamic,
+)
+from src.types.concrete_types import OpTypeFloat, OpTypeVector
 
 N = 1000
 monitor = Monitor()
@@ -63,7 +65,7 @@ class TestArithmetic(unittest.TestCase):
         )[-1]
 
         self.assertEqual(vector_extract.type, vec_const.get_base_type())
-    
+
     def test_vector_insert_preserves_type(self):
         vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
 
@@ -76,29 +78,25 @@ class TestArithmetic(unittest.TestCase):
     def test_composite_extract_has_correct_type(self):
         vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
 
-        vector_extract: OpCompositeExtract = OpCompositeExtract().fuzz(
-            self.context
-        )[-1]
+        vector_extract: OpCompositeExtract = OpCompositeExtract().fuzz(self.context)[-1]
 
         self.assertEqual(vector_extract.type, vec_const.get_base_type())
 
     def test_composite_insert_preserves_type(self):
         vec_const: OpConstantComposite = create_vector_const(self.context, OpTypeFloat)
 
-        vector_insert: OpCompositeInsert = OpCompositeInsert().fuzz(
-            self.context
-        )[-1]
+        vector_insert: OpCompositeInsert = OpCompositeInsert().fuzz(self.context)[-1]
 
         self.assertEqual(vector_insert.type, vec_const.type)
-        
+
     def test_transpose_has_correct_shape(self):
         create_vector_const(self.context, OpTypeFloat, size=4)
         create_vector_const(self.context, OpTypeFloat, size=2)
 
         outer_product: OpOuterProduct = OpOuterProduct().fuzz(self.context)[-1]
         self.context.symbol_table[outer_product] = outer_product.id
-        
+
         transpose: OpTranspose = OpTranspose().fuzz(self.context)[-1]
-        
+
         self.assertEqual(len(transpose.type), len(outer_product.type.type))
         self.assertEqual(len(transpose.type.type), len(outer_product.type))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,5 +1,4 @@
 import copy
-from dataclasses import replace
 import unittest
 from src import FuzzDelegator
 from src.constants import OpConstant, OpConstantFalse, OpConstantTrue

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,12 +1,11 @@
 import copy
-from dataclasses import replace
 import unittest
+from run_local import SPIRVSmithConfig
 from src.monitor import Monitor
 from src.enums import ExecutionModel
-from src import PARAMETRIZATIONS, FuzzDelegator, Type, members
+from src import FuzzDelegator, Type
 from src.operators.arithmetic.scalar_arithmetic import OpISub
 from src.context import Context
-from run_local import SPIRVSmithConfig
 from src.types.abstract_types import ArithmeticType, MiscType
 from src.types.concrete_types import (
     OpTypeBool,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,5 +1,4 @@
 import copy
-from dataclasses import replace
 import unittest
 from src import FuzzDelegator
 from src.memory import OpLoad

--- a/tests/test_recondition.py
+++ b/tests/test_recondition.py
@@ -1,17 +1,15 @@
 import copy
-from typing import Optional
 import unittest
 from src.monitor import Monitor
 from src.recondition import recondition
 from run_local import SPIRVSmithConfig
-from src import FuzzDelegator, Type
-from src.constants import OpConstant, OpConstantComposite
+from src import FuzzDelegator
+from src.constants import OpConstantComposite
 from src.context import Context
 from src.enums import ExecutionModel
 from src.operators.arithmetic.scalar_arithmetic import OpSMod
 from src.operators.composite import OpVectorExtractDynamic
 from src.types.concrete_types import OpTypeInt, OpTypeVector
-from dataclasses import replace
 
 monitor = Monitor()
 config = SPIRVSmithConfig()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,122 @@
+import copy
+import unittest
+from src import FuzzDelegator, Type
+from src.constants import OpConstant, OpConstantComposite
+from src.monitor import Monitor
+from src.enums import ExecutionModel
+from src.context import Context
+from run_local import SPIRVSmithConfig
+from src.predicates import HaveSameBaseType, HaveSameType, HaveSameTypeLength
+from src.types.concrete_types import OpTypeFloat, OpTypeInt, OpTypeVector
+
+N = 1000
+monitor = Monitor()
+config = SPIRVSmithConfig()
+init_strategy = copy.deepcopy(config.strategy)
+init_limits = copy.deepcopy(config.limits)
+
+config.misc.broadcast_generated_shaders = False
+config.misc.start_web_server = False
+
+
+def create_vector_const(
+    context: Context, inner_type: Type, size: int = 4, value: int = 42
+):
+    const: OpConstant = context.create_on_demand_numerical_constant(
+        inner_type, value=value, width=32
+    )
+
+    vector_type = OpTypeVector()
+    vector_type.type = const.type
+    vector_type.size = size
+    context.add_to_tvc(vector_type)
+
+    vector_const = OpConstantComposite()
+    vector_const.type = vector_type
+    vector_const.constituents = tuple([const for _ in range(size)])
+    context.add_to_tvc(vector_const)
+    return vector_const
+
+
+class TestArithmetic(unittest.TestCase):
+    def setUp(self):
+        FuzzDelegator.reset_parametrizations()
+        config.limits = copy.deepcopy(init_limits)
+        config.strategy = copy.deepcopy(init_strategy)
+        self.context: Context = Context.create_global_context(
+            ExecutionModel.GLCompute, config, monitor
+        )
+
+    def test_ints_same_width_and_signedness_are_equal(self):
+        const1: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeInt, value=42, width=32, signed=0
+        )
+        const2: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeInt, value=69, width=32, signed=0
+        )
+
+        self.assertEqual(const1.type, const2.type)
+        self.assertTrue(HaveSameType(const1, const2))
+
+        const3: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeInt, value=42, width=32, signed=1
+        )
+        const4: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeInt, value=69, width=32, signed=1
+        )
+
+        self.assertEqual(const3.type, const4.type)
+        self.assertTrue(HaveSameType(const3, const4))
+
+        self.assertNotEqual(const1.type, const3.type)
+        self.assertNotEqual(const2.type, const4.type)
+
+        self.assertFalse(HaveSameType(const1, const3))
+        self.assertFalse(HaveSameType(const2, const4))
+
+    def test_floats_same_width_are_equal(self):
+        const1: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeFloat, value=42, width=32
+        )
+        const2: OpConstant = self.context.create_on_demand_numerical_constant(
+            OpTypeFloat, value=69, width=32
+        )
+
+        self.assertEqual(const1.type, const2.type)
+        self.assertTrue(HaveSameType(const1, const2))
+
+    def test_vectors_same_size_and_base_type_are_equal(self):
+        vec_const1: OpConstantComposite = create_vector_const(
+            self.context, OpTypeInt, size=4, value=42
+        )
+        vec_const2: OpConstantComposite = create_vector_const(
+            self.context, OpTypeInt, size=4, value=69
+        )
+
+        self.assertEqual(vec_const1.type, vec_const2.type)
+        self.assertTrue(HaveSameType(vec_const1, vec_const2))
+        self.assertTrue(HaveSameBaseType(vec_const1, vec_const2))
+
+    def test_vectors_same_size_and_different_base_type_are_not_equal(self):
+        vec_const1: OpConstantComposite = create_vector_const(
+            self.context, OpTypeInt, 4, value=42
+        )
+        vec_const2: OpConstantComposite = create_vector_const(
+            self.context, OpTypeFloat, 4, value=69
+        )
+
+        self.assertNotEqual(vec_const1.type, vec_const2.type)
+        self.assertFalse(HaveSameType(vec_const1, vec_const2))
+        self.assertFalse(HaveSameBaseType(vec_const1, vec_const2))
+
+    def test_vectors_different_size_and_same_base_type_are_not_equal(self):
+        vec_const1: OpConstantComposite = create_vector_const(
+            self.context, OpTypeInt, 2, value=42
+        )
+        vec_const2: OpConstantComposite = create_vector_const(
+            self.context, OpTypeInt, 4, value=69
+        )
+
+        self.assertNotEqual(vec_const1.type, vec_const2.type)
+        self.assertFalse(HaveSameType(vec_const1, vec_const2))
+        self.assertTrue(HaveSameBaseType(vec_const1, vec_const2))

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ from src.monitor import Monitor
 from src.enums import ExecutionModel
 from src.context import Context
 from run_local import SPIRVSmithConfig
-from src.predicates import HaveSameBaseType, HaveSameType, HaveSameTypeLength
+from src.predicates import HaveSameBaseType, HaveSameType
 from src.types.concrete_types import OpTypeFloat, OpTypeInt, OpTypeVector
 
 N = 1000


### PR DESCRIPTION
This PR achieves the following:

- Implement `OpVectorShuffle`
- Implement `OpCompositeExtract`
- Implement `OpCompositeInsert`
- Implement `OpCopyObject`
- Implement `OpTranspose`
- Fix bugs related to mismatching shapes in linear algebra operators
- Add tests for the SPIRVSmith type system
- Allow `OpConstantComposite` to generate matrices